### PR TITLE
Fix windows base unity path.

### DIFF
--- a/open-unity.sh
+++ b/open-unity.sh
@@ -49,7 +49,7 @@ BIN2TXT="binary2text"
 SED="sed"
 
 if [[ x"$OS" == x"Windows" ]]; then
-  BASEUNITYPATH="C:/Program\ Files/Unity/Hub/Editor"
+  BASEUNITYPATH="/c/Program Files/Unity/Hub/Editor"
   BIN2TXT="${BIN2TXT}.exe"
 fi
 


### PR DESCRIPTION
Conditional usage was already being quoted, so escape was being treated literally. The editor installs weren't being found.

Also changed C:/ to /c/ for consistency with OS Windows check.